### PR TITLE
Fix GetMongoDB and add task update endpoint

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -13,7 +13,6 @@ import (
 
 var MongoClient *mongo.Client
 var OperaryDB *mongo.Database
-var mongoDB *mongo.Database
 
 func InitMongo() {
 	uri := os.Getenv("MONGO_URI")
@@ -41,5 +40,12 @@ func InitMongo() {
 	fmt.Println("✅ MongoDB connected:", dbName)
 }
 func GetMongoDB() *mongo.Database {
-	return mongoDB
+	// Return the initialized database instance used by the rest of the
+	// application. This was previously returning an unassigned variable
+	// which caused nil pointer errors when accessing the DB from other
+	// packages.
+	// During initialization OperaryDB is set to the active database
+	// connection. Simply return it here so other packages can interact
+	// with MongoDB after initialization.
+	return OperaryDB
 }

--- a/backend/internal/handlers/tasks_audited.go
+++ b/backend/internal/handlers/tasks_audited.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/elkarto91/operary/internal/models"
+	"github.com/go-chi/chi/v5"
 )
 
 func ListTasksHandler(w http.ResponseWriter, r *http.Request) {
@@ -37,6 +38,37 @@ func CreateTaskHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_ = models.RecordAudit("task", task.ID, "create", req.UserID, task)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(task)
+}
+
+// UpdateTaskHandler handles partial updates to a task's status or notes. It is
+// mapped to PATCH /v1/tasks/{taskID}.
+func UpdateTaskHandler(w http.ResponseWriter, r *http.Request) {
+	taskID := chi.URLParam(r, "taskID")
+	if taskID == "" {
+		http.Error(w, "Missing task ID", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		Status string `json:"status"`
+		Notes  string `json:"notes"`
+		UserID string `json:"user_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	task, err := models.UpdateTask(taskID, req.Status, req.Notes)
+	if err != nil {
+		http.Error(w, "Failed to update task", http.StatusInternalServerError)
+		return
+	}
+
+	_ = models.RecordAudit("task", taskID, "update", req.UserID, task)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(task)

--- a/backend/internal/models/task.go
+++ b/backend/internal/models/task.go
@@ -57,3 +57,46 @@ func GetAllTasks() ([]Task, error) {
 
 	return tasks, nil
 }
+
+// UpdateTask updates the task status and/or appends a note. The updated task is
+// returned after modification. If neither status nor note is provided, the
+// task is left unchanged and the current record is returned.
+func UpdateTask(id, status, note string) (*Task, error) {
+	filter := bson.M{"_id": id}
+
+	update := bson.M{}
+	setFields := bson.M{}
+	if status != "" {
+		setFields["status"] = status
+	}
+	if len(setFields) > 0 {
+		update["$set"] = setFields
+	}
+	if note != "" {
+		update["$push"] = bson.M{"notes": note}
+	}
+
+	if len(update) == 0 {
+		// Nothing to update; just return the existing task
+		var existing Task
+		err := taskCollection.FindOne(context.TODO(), filter).Decode(&existing)
+		if err != nil {
+			return nil, err
+		}
+		return &existing, nil
+	}
+
+	// Apply the update and then fetch the new record
+	_, err := taskCollection.UpdateOne(context.TODO(), filter, update)
+	if err != nil {
+		return nil, err
+	}
+
+	var updated Task
+	err = taskCollection.FindOne(context.TODO(), filter).Decode(&updated)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updated, nil
+}

--- a/backend/router/routes.go
+++ b/backend/router/routes.go
@@ -54,6 +54,7 @@ func NewRouterWithLogger(logger *zap.SugaredLogger) http.Handler {
 	r.Route("/v1/tasks", func(r chi.Router) {
 		r.Get("/", handlers.ListTasksHandler)
 		r.Post("/", handlers.CreateTaskHandler)
+		r.Patch("/{taskID}", handlers.UpdateTaskHandler)
 	})
 
 	// Shift endpoints


### PR DESCRIPTION
## Summary
- fix `GetMongoDB` to return initialized DB
- implement `UpdateTask` model method
- expose PATCH /v1/tasks/{taskID} route and handler
- record audit entry when updating tasks

## Testing
- `go test ./...` *(fails: forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_6863dd0ed198832dbd530e0ab90ec2be