### PR TITLE
Restore task utilities

### DIFF
--- a/backend/internal/models/task.go
+++ b/backend/internal/models/task.go
@@ -57,3 +57,74 @@ func GetAllTasks() ([]Task, error) {
 
 	return tasks, nil
 }
+
+// GetTasksByTimeRange returns all tasks created between the given start and end
+// times. Tasks are filtered based on the "created_at" timestamp stored in the
+// database.
+func GetTasksByTimeRange(start, end time.Time) ([]Task, error) {
+	filter := bson.M{
+		"created_at": bson.M{
+			"$gte": start,
+			"$lte": end,
+		},
+	}
+
+	cursor, err := taskCollection.Find(context.TODO(), filter)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(context.TODO())
+
+	var tasks []Task
+	for cursor.Next(context.TODO()) {
+		var task Task
+		if err := cursor.Decode(&task); err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+	return tasks, nil
+}
+
+// UpdateTask updates the task status and/or appends a note. The updated task is
+// returned after modification. If neither status nor note is provided, the task
+// is left unchanged and the current record is returned.
+func UpdateTask(id, status, note string) (*Task, error) {
+	filter := bson.M{"_id": id}
+
+	update := bson.M{}
+	setFields := bson.M{}
+	if status != "" {
+		setFields["status"] = status
+	}
+	if len(setFields) > 0 {
+		update["$set"] = setFields
+	}
+	if note != "" {
+		update["$push"] = bson.M{"notes": note}
+	}
+
+	if len(update) == 0 {
+		// Nothing to update; just return the existing task
+		var existing Task
+		err := taskCollection.FindOne(context.TODO(), filter).Decode(&existing)
+		if err != nil {
+			return nil, err
+		}
+		return &existing, nil
+	}
+
+	// Apply the update and then fetch the new record
+	_, err := taskCollection.UpdateOne(context.TODO(), filter, update)
+	if err != nil {
+		return nil, err
+	}
+
+	var updated Task
+	err = taskCollection.FindOne(context.TODO(), filter).Decode(&updated)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updated, nil
+}


### PR DESCRIPTION
## Summary
- reintroduce `GetTasksByTimeRange` and `UpdateTask`

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6863e0bce4f0832db0ffca0be5673cc1