### PR TITLE
Add TraceBoard incident module

### DIFF
--- a/backend/internal/traceboard/handler/incident.go
+++ b/backend/internal/traceboard/handler/incident.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/elkarto91/operary/internal/traceboard/model"
+	"github.com/elkarto91/operary/internal/traceboard/usecase"
+	"github.com/go-chi/chi/v5"
+)
+
+// SubmitReport handles POST /traceboard/incidents
+func SubmitReport(w http.ResponseWriter, r *http.Request) {
+	var report model.IncidentReport
+	if err := json.NewDecoder(r.Body).Decode(&report); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	saved, err := usecase.SubmitReport(report)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	json.NewEncoder(w).Encode(saved)
+}
+
+// ListReports handles GET /traceboard/incidents
+func ListReports(w http.ResponseWriter, r *http.Request) {
+	reports, err := usecase.GetReports()
+	if err != nil {
+		http.Error(w, "Failed to retrieve incidents", http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(reports)
+}
+
+// GetReport handles GET /traceboard/incidents/{id}
+func GetReport(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	report, err := usecase.GetReport(id)
+	if err != nil {
+		http.Error(w, "Incident not found", http.StatusNotFound)
+		return
+	}
+	json.NewEncoder(w).Encode(report)
+}

--- a/backend/internal/traceboard/model/incident.go
+++ b/backend/internal/traceboard/model/incident.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// IncidentReport captures metadata and analysis for an operational incident.
+type IncidentReport struct {
+	ID              primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Title           string             `json:"title"`
+	Description     string             `json:"description"`
+	RootCause       string             `json:"root_cause"`
+	Recommendations string             `json:"recommendations"`
+	LinkedTaskID    *string            `json:"linked_task_id,omitempty" bson:"linked_task_id,omitempty"`
+	LinkedAuditID   *string            `json:"linked_audit_id,omitempty" bson:"linked_audit_id,omitempty"`
+	FaultTreeJSON   string             `json:"fault_tree_json"`
+	Tags            []string           `json:"tags"`
+	ReportedBy      string             `json:"reported_by"`
+	CreatedAt       time.Time          `json:"created_at"`
+}

--- a/backend/internal/traceboard/repo/incident_repository.go
+++ b/backend/internal/traceboard/repo/incident_repository.go
@@ -1,0 +1,50 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/elkarto91/operary/internal/traceboard/model"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var collection *mongo.Collection
+
+// InitMongoCollection stores the collection handle for incident reports.
+func InitMongoCollection(db *mongo.Database) {
+	collection = db.Collection("traceboard_incidents")
+}
+
+// Save inserts a new incident report with a creation timestamp.
+func Save(report model.IncidentReport) (model.IncidentReport, error) {
+	report.ID = primitive.NewObjectID()
+	report.CreatedAt = time.Now()
+	_, err := collection.InsertOne(context.Background(), report)
+	return report, err
+}
+
+// List returns all stored incident reports.
+func List() ([]model.IncidentReport, error) {
+	cursor, err := collection.Find(context.Background(), bson.M{})
+	if err != nil {
+		return nil, err
+	}
+	var results []model.IncidentReport
+	err = cursor.All(context.Background(), &results)
+	return results, err
+}
+
+// GetByID fetches a single report by its ObjectID.
+func GetByID(id primitive.ObjectID) (model.IncidentReport, error) {
+	var result model.IncidentReport
+	err := collection.FindOne(context.Background(), bson.M{"_id": id}).Decode(&result)
+	return result, err
+}
+
+// DeleteByID removes a report, used by admin tools.
+func DeleteByID(id primitive.ObjectID) error {
+	_, err := collection.DeleteOne(context.Background(), bson.M{"_id": id})
+	return err
+}

--- a/backend/internal/traceboard/traceboard.go
+++ b/backend/internal/traceboard/traceboard.go
@@ -1,0 +1,22 @@
+package traceboard
+
+import (
+	"github.com/elkarto91/operary/internal/traceboard/handler"
+	"github.com/elkarto91/operary/internal/traceboard/repo"
+	"github.com/go-chi/chi/v5"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Init configures the MongoDB collection for TraceBoard.
+func Init(db *mongo.Database) {
+	repo.InitMongoCollection(db)
+}
+
+// RegisterRoutes registers TraceBoard HTTP routes.
+func RegisterRoutes(r chi.Router) {
+	r.Route("/traceboard", func(r chi.Router) {
+		r.Post("/incidents", handler.SubmitReport)
+		r.Get("/incidents", handler.ListReports)
+		r.Get("/incidents/{id}", handler.GetReport)
+	})
+}

--- a/backend/internal/traceboard/usecase/incident_usecase.go
+++ b/backend/internal/traceboard/usecase/incident_usecase.go
@@ -1,0 +1,31 @@
+package usecase
+
+import (
+	"fmt"
+
+	"github.com/elkarto91/operary/internal/traceboard/model"
+	"github.com/elkarto91/operary/internal/traceboard/repo"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// SubmitReport validates and saves an incident report.
+func SubmitReport(report model.IncidentReport) (model.IncidentReport, error) {
+	if len(report.Title) <= 5 {
+		return model.IncidentReport{}, fmt.Errorf("title too short")
+	}
+	return repo.Save(report)
+}
+
+// GetReports returns all incident reports.
+func GetReports() ([]model.IncidentReport, error) {
+	return repo.List()
+}
+
+// GetReport returns a single report by ID string.
+func GetReport(id string) (model.IncidentReport, error) {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return model.IncidentReport{}, err
+	}
+	return repo.GetByID(objID)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elkarto91/operary/internal/permitgrid"
 	"github.com/elkarto91/operary/internal/sensorvault"
 	"github.com/elkarto91/operary/internal/services"
+	"github.com/elkarto91/operary/internal/traceboard"
 	"github.com/elkarto91/operary/router"
 	"github.com/joho/godotenv"
 	"go.uber.org/zap"
@@ -34,6 +35,7 @@ func main() {
 	corepad.Init(db)
 	auditsync.Init(db)
 	permitgrid.Init(db) // ✅ NEW
+	traceboard.Init(db)
 	equiptrust.Init(db)
 	sensorvault.Init(db)
 

--- a/backend/router/routes.go
+++ b/backend/router/routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elkarto91/operary/internal/opsmirror"
 	"github.com/elkarto91/operary/internal/permitgrid"
 	"github.com/elkarto91/operary/internal/sensorvault"
+	"github.com/elkarto91/operary/internal/traceboard"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -31,6 +32,7 @@ func NewRouterWithLogger(logger *zap.SugaredLogger) http.Handler {
 	equiptrust.RegisterRoutes(r)
 	sensorvault.RegisterRoutes(r)
 	permitgrid.RegisterRoutes(r)
+	traceboard.RegisterRoutes(r)
 
 	r.Use(handlers.MetricsMiddleware)
 	r.Get("/v1/metrics", handlers.MetricsHandler)


### PR DESCRIPTION
## Summary
- implement TraceBoard module for incident reports
- register new routes and initialization

## Testing
- `go test ./...` *(fails: downloading modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6863e5c4ab6c832db0e9788f9840e4f0