### PR TITLE
Add module overview docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ All API requests must include an `X-Org-Token` header for access control.
 * **Markdown** (for all product collateral)
 * **GitHub Pages + Jekyll** (linked portfolio docs)
 
+## Module Overview
+Operary is organized into small Go packages under `backend/internal`. Each package exposes HTTP handlers, a usecase layer, and a Mongo-backed repository. The main modules are:
+- **CorePad** – operator notes
+- **OpsMirror** – live system status
+- **AuditSync** – digital audit log
+- **PermitGrid** – permit-to-work requests
+- **EquipTrust** – equipment ledger
+- **SensorVault** – machine event storage
+A full list of functions is provided in [docs/overview.md](docs/overview.md).
+
 ---
 
 # 📚 Learn More

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,111 @@
+# Operary – Module & Function Overview
+
+This document summarizes the backend modules found in the `backend/internal` directory and the key functions provided by each package. It is intended as a high-level reference when exploring the codebase.
+
+## CorePad
+Operator note system for capturing shift observations.
+
+**Main handlers**
+- `CreateNoteHandler` – POST `/corepad/notes`
+- `GetNoteHandler` – GET `/corepad/notes/{id}`
+
+**Usecase layer**
+- `CreateNote(content, author, tags)`
+- `GetNote(id)`
+
+**Repository layer**
+- `SaveNote(Note)` and `GetNoteByID(id)`
+
+## OpsMirror
+Dashboard showing current state of critical systems.
+
+**Main handler**
+- `GetStatusDashboard` – GET `/opsmirror/dashboard`
+
+**Usecase layer**
+- `FetchStatuses()`
+
+**Repository layer**
+- `GetAllStatuses()`
+- `UpsertStatus(status)`
+
+## AuditSync
+Digital audit trail service.
+
+**Main handlers**
+- `CreateAuditEntry` – POST `/auditsync/entries`
+- `GetAuditEntries` – GET `/auditsync/entries`
+
+**Usecase layer**
+- `CreateAudit(request)`
+- `ListAudits()`
+
+**Repository layer**
+- `SaveAudit(AuditEntry)`
+- `ListAudits()`
+
+## PermitGrid
+Permit-to-work request management.
+
+**Main handlers**
+- `CreatePermitRequest` – POST `/permitgrid/requests`
+- `ListPermitRequests` – GET `/permitgrid/requests`
+- `ApprovePermit` – PATCH `/permitgrid/requests/{id}/approve`
+- `RejectPermit` – PATCH `/permitgrid/requests/{id}/reject`
+
+**Usecase layer**
+- `CreatePermit(request)`
+- `ListPermits()`
+- `ApprovePermit(id, approver)`
+- `RejectPermit(id, approver)`
+
+**Repository layer**
+- `SavePermit(Permit)`
+- `ListPermits()`
+- `UpdatePermitStatus(id, status, approver)`
+
+## EquipTrust
+Equipment handover ledger.
+
+**Main handlers**
+- `CheckoutEquipment` – POST `/equiptrust/checkout`
+- `ReturnEquipment` – PATCH `/equiptrust/return/{id}`
+- `ListLedger` – GET `/equiptrust/ledger`
+
+**Usecase layer**
+- `Checkout(request)`
+- `Return(id, time)`
+- `ListLedger()`
+
+**Repository layer**
+- `Save(EquipmentLedger)`
+- `UpdateReturn(id, time)`
+- `List()`
+
+## SensorVault
+Recording machine events and telemetry.
+
+**Main handlers**
+- `RecordEvent` – POST `/sensorvault/events`
+- `ListEvents` – GET `/sensorvault/events`
+
+**Usecase layer**
+- `RecordEvent(request)`
+- `GetEvents()`
+
+**Repository layer**
+- `Save(SensorEvent)`
+- `List()`
+
+## Shared Models
+Core task and shift logic lives under `internal/models`:
+- `Task` with functions `CreateTask`, `GetAllTasks`, `UpdateTask`, `GetTasksByTimeRange`.
+- `Shift` with functions `StartShift`, `CloseShift`, `GetShiftByID`.
+- `AuditLog` utilities such as `RecordAudit` and `GetAuditLogs`.
+- `GenerateShiftReport` for simple shift reports.
+
+## Services
+Background workers live in `internal/services`.
+- `StartNotificationService(logger)` prints periodic heartbeats and represents future integrations.
+
+For endpoint details see the OpenAPI specifications in the `api_spec/` directory.


### PR DESCRIPTION
## Summary
- include a high-level module and function overview in a new `docs/overview.md`
- reference new section from the README so the overall picture links to modules

## Testing
- `go vet ./...` *(fails: forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_6863e6cbf484832dabbd88cf791da547