### PR TITLE
Implement SensorVault and TraceBoard endpoints

### DIFF
--- a/api_spec/openapi.yaml
+++ b/api_spec/openapi.yaml
@@ -19,6 +19,8 @@ tags:
   - name: Tasks
   - name: Shifts
   - name: Audit Logs
+  - name: SensorVault
+  - name: TraceBoard
 
 components:
   securitySchemes:
@@ -68,20 +70,76 @@ components:
         closed:
           type: boolean
 
-    AuditEntry:
-      type: object
-      properties:
-        entity_type:
+  AuditEntry:
+    type: object
+    properties:
+      entity_type:
+        type: string
+      entity_id:
+        type: string
+      action:
+        type: string
+      user_id:
+        type: string
+      timestamp:
+        type: string
+        format: date-time
+
+  SensorEvent:
+    type: object
+    properties:
+      id:
+        type: string
+      source_id:
+        type: string
+      event_type:
+        type: string
+      timestamp:
+        type: string
+        format: date-time
+      description:
+        type: string
+      tags:
+        type: array
+        items:
           type: string
-        entity_id:
+      task_id:
+        type: string
+        nullable: true
+      audit_id:
+        type: string
+        nullable: true
+
+  IncidentReport:
+    type: object
+    properties:
+      id:
+        type: string
+      title:
+        type: string
+      description:
+        type: string
+      root_cause:
+        type: string
+      recommendations:
+        type: string
+      linked_task_id:
+        type: string
+        nullable: true
+      linked_audit_id:
+        type: string
+        nullable: true
+      fault_tree_json:
+        type: string
+      tags:
+        type: array
+        items:
           type: string
-        action:
-          type: string
-        user_id:
-          type: string
-        timestamp:
-          type: string
-          format: date-time
+      reported_by:
+        type: string
+      created_at:
+        type: string
+        format: date-time
 
 security:
   - OrgTokenAuth: []
@@ -204,3 +262,135 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/AuditEntry"
+
+  /sensorvault/events:
+    post:
+      tags: [SensorVault]
+      summary: Record a sensor event
+      security:
+        - OrgTokenAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SensorEvent"
+      responses:
+        200:
+          description: Event recorded
+    get:
+      tags: [SensorVault]
+      summary: List sensor events
+      security:
+        - OrgTokenAuth: []
+      responses:
+        200:
+          description: List of sensor events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SensorEvent"
+
+  /sensorvault/events/{id}:
+    get:
+      tags: [SensorVault]
+      summary: Get a sensor event by ID
+      security:
+        - OrgTokenAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Sensor event
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SensorEvent"
+        404:
+          description: Event not found
+    delete:
+      tags: [SensorVault]
+      summary: Delete a sensor event
+      security:
+        - OrgTokenAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Event deleted
+
+  /traceboard/incidents:
+    post:
+      tags: [TraceBoard]
+      summary: Submit an incident report
+      security:
+        - OrgTokenAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IncidentReport"
+      responses:
+        200:
+          description: Report saved
+    get:
+      tags: [TraceBoard]
+      summary: List incident reports
+      security:
+        - OrgTokenAuth: []
+      responses:
+        200:
+          description: List of incident reports
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/IncidentReport"
+
+  /traceboard/incidents/{id}:
+    get:
+      tags: [TraceBoard]
+      summary: Get incident report by ID
+      security:
+        - OrgTokenAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Incident report
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IncidentReport"
+        404:
+          description: Report not found
+    delete:
+      tags: [TraceBoard]
+      summary: Delete incident report
+      security:
+        - OrgTokenAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Report deleted

--- a/backend/internal/sensorvault/handler/event.go
+++ b/backend/internal/sensorvault/handler/event.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/elkarto91/operary/internal/sensorvault/usecase"
+	"github.com/go-chi/chi/v5"
 )
 
 func RecordEvent(w http.ResponseWriter, r *http.Request) {
@@ -31,4 +32,23 @@ func ListEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(events)
+}
+
+func GetEvent(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	event, err := usecase.GetEvent(id)
+	if err != nil {
+		http.Error(w, "Event not found", http.StatusNotFound)
+		return
+	}
+	json.NewEncoder(w).Encode(event)
+}
+
+func DeleteEvent(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := usecase.DeleteEvent(id); err != nil {
+		http.Error(w, "Failed to delete", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }

--- a/backend/internal/sensorvault/repo/event_repository.go
+++ b/backend/internal/sensorvault/repo/event_repository.go
@@ -33,3 +33,14 @@ func List() ([]model.SensorEvent, error) {
 	err = cursor.All(context.Background(), &results)
 	return results, err
 }
+
+func GetByID(id primitive.ObjectID) (model.SensorEvent, error) {
+	var result model.SensorEvent
+	err := collection.FindOne(context.Background(), bson.M{"_id": id}).Decode(&result)
+	return result, err
+}
+
+func DeleteByID(id primitive.ObjectID) error {
+	_, err := collection.DeleteOne(context.Background(), bson.M{"_id": id})
+	return err
+}

--- a/backend/internal/sensorvault/sensorvault.go
+++ b/backend/internal/sensorvault/sensorvault.go
@@ -15,5 +15,7 @@ func RegisterRoutes(r chi.Router) {
 	r.Route("/sensorvault", func(r chi.Router) {
 		r.Post("/events", handler.RecordEvent)
 		r.Get("/events", handler.ListEvents)
+		r.Get("/events/{id}", handler.GetEvent)
+		r.Delete("/events/{id}", handler.DeleteEvent)
 	})
 }

--- a/backend/internal/sensorvault/usecase/event_usecase.go
+++ b/backend/internal/sensorvault/usecase/event_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"github.com/elkarto91/operary/internal/sensorvault/model"
 	"github.com/elkarto91/operary/internal/sensorvault/repo"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type SensorEventRequest struct {
@@ -28,4 +29,20 @@ func RecordEvent(req SensorEventRequest) (model.SensorEvent, error) {
 
 func GetEvents() ([]model.SensorEvent, error) {
 	return repo.List()
+}
+
+func GetEvent(id string) (model.SensorEvent, error) {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return model.SensorEvent{}, err
+	}
+	return repo.GetByID(objID)
+}
+
+func DeleteEvent(id string) error {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+	return repo.DeleteByID(objID)
 }

--- a/backend/internal/traceboard/handler/incident.go
+++ b/backend/internal/traceboard/handler/incident.go
@@ -44,3 +44,12 @@ func GetReport(w http.ResponseWriter, r *http.Request) {
 	}
 	json.NewEncoder(w).Encode(report)
 }
+
+func DeleteReport(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := usecase.DeleteReport(id); err != nil {
+		http.Error(w, "Failed to delete", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/backend/internal/traceboard/traceboard.go
+++ b/backend/internal/traceboard/traceboard.go
@@ -18,5 +18,6 @@ func RegisterRoutes(r chi.Router) {
 		r.Post("/incidents", handler.SubmitReport)
 		r.Get("/incidents", handler.ListReports)
 		r.Get("/incidents/{id}", handler.GetReport)
+		r.Delete("/incidents/{id}", handler.DeleteReport)
 	})
 }

--- a/backend/internal/traceboard/usecase/incident_usecase.go
+++ b/backend/internal/traceboard/usecase/incident_usecase.go
@@ -29,3 +29,11 @@ func GetReport(id string) (model.IncidentReport, error) {
 	}
 	return repo.GetByID(objID)
 }
+
+func DeleteReport(id string) error {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return err
+	}
+	return repo.DeleteByID(objID)
+}


### PR DESCRIPTION
## Summary
- extend API spec with SensorVault and TraceBoard endpoints
- add SensorVault CRUD functions and routes
- add TraceBoard delete report feature

## Testing
- `go test ./...` *(fails: network access restriction)*

------
https://chatgpt.com/codex/tasks/task_e_6863e9c330f8832d99d0d6711884c7f6