### PR TITLE
Add initial FlowGrid module

### DIFF
--- a/backend/internal/flowgrid/flowgrid.go
+++ b/backend/internal/flowgrid/flowgrid.go
@@ -1,0 +1,20 @@
+package flowgrid
+
+import (
+	"github.com/elkarto91/operary/internal/flowgrid/handler"
+	"github.com/go-chi/chi/v5"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Init initializes resources for FlowGrid. No DB setup yet.
+func Init(db *mongo.Database) {
+	_ = db // placeholder for future persistence
+}
+
+// RegisterRoutes exposes FlowGrid HTTP routes.
+func RegisterRoutes(r chi.Router) {
+	r.Route("/flowgrid", func(r chi.Router) {
+		r.Post("/schedule", handler.GenerateSchedule)
+		r.Post("/match-skills", handler.MatchSkills)
+	})
+}

--- a/backend/internal/flowgrid/handler/flowgrid.go
+++ b/backend/internal/flowgrid/handler/flowgrid.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/elkarto91/operary/internal/flowgrid/model"
+	"github.com/elkarto91/operary/internal/flowgrid/usecase"
+)
+
+// MatchSkills accepts a ScheduleRequest and returns best-fit assignments.
+func MatchSkills(w http.ResponseWriter, r *http.Request) {
+	var req model.ScheduleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	assignments := usecase.MatchSkills(req.Workers, req.Tasks)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(assignments)
+}
+
+// GenerateSchedule is an alias of MatchSkills for now.
+func GenerateSchedule(w http.ResponseWriter, r *http.Request) {
+	MatchSkills(w, r)
+}

--- a/backend/internal/flowgrid/model/flowgrid.go
+++ b/backend/internal/flowgrid/model/flowgrid.go
@@ -1,0 +1,28 @@
+package model
+
+// Worker represents an operator available for task assignments.
+type Worker struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	Skills    []string `json:"skills"`
+	Available bool     `json:"available"`
+}
+
+// Task defines work requiring a particular skill set.
+type Task struct {
+	ID             string   `json:"id"`
+	Description    string   `json:"description"`
+	RequiredSkills []string `json:"required_skills"`
+}
+
+// ScheduleRequest bundles workers and tasks for scheduling.
+type ScheduleRequest struct {
+	Workers []Worker `json:"workers"`
+	Tasks   []Task   `json:"tasks"`
+}
+
+// Assignment ties a task to the worker selected to perform it.
+type Assignment struct {
+	TaskID   string `json:"task_id"`
+	WorkerID string `json:"worker_id"`
+}

--- a/backend/internal/flowgrid/usecase/flowgrid_usecase.go
+++ b/backend/internal/flowgrid/usecase/flowgrid_usecase.go
@@ -1,0 +1,41 @@
+package usecase
+
+import "github.com/elkarto91/operary/internal/flowgrid/model"
+
+// MatchSkills iterates over tasks and assigns them to available workers
+// with matching skills. A worker can only be assigned once.
+func MatchSkills(workers []model.Worker, tasks []model.Task) []model.Assignment {
+	used := make(map[string]bool)
+	var assignments []model.Assignment
+
+	for _, task := range tasks {
+		for _, w := range workers {
+			if !w.Available || used[w.ID] {
+				continue
+			}
+			if hasSkills(w.Skills, task.RequiredSkills) {
+				assignments = append(assignments, model.Assignment{
+					TaskID:   task.ID,
+					WorkerID: w.ID,
+				})
+				used[w.ID] = true
+				break
+			}
+		}
+	}
+
+	return assignments
+}
+
+func hasSkills(workerSkills, required []string) bool {
+	skillMap := make(map[string]bool, len(workerSkills))
+	for _, s := range workerSkills {
+		skillMap[s] = true
+	}
+	for _, s := range required {
+		if !skillMap[s] {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/elkarto91/operary/internal/auditsync"
 	"github.com/elkarto91/operary/internal/corepad"
 	"github.com/elkarto91/operary/internal/equiptrust"
+	"github.com/elkarto91/operary/internal/flowgrid"
 	"github.com/elkarto91/operary/internal/opsmirror"
 	"github.com/elkarto91/operary/internal/permitgrid"
 	"github.com/elkarto91/operary/internal/sensorvault"
@@ -35,6 +36,7 @@ func main() {
 	corepad.Init(db)
 	auditsync.Init(db)
 	permitgrid.Init(db) // ✅ NEW
+	flowgrid.Init(db)
 	traceboard.Init(db)
 	equiptrust.Init(db)
 	sensorvault.Init(db)

--- a/backend/router/routes.go
+++ b/backend/router/routes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/elkarto91/operary/internal/auditsync"
 	"github.com/elkarto91/operary/internal/corepad"
 	"github.com/elkarto91/operary/internal/equiptrust"
+	"github.com/elkarto91/operary/internal/flowgrid"
 	"github.com/elkarto91/operary/internal/handlers"
 	authmiddleware "github.com/elkarto91/operary/internal/middleware"
 	"github.com/elkarto91/operary/internal/opsmirror"
@@ -32,6 +33,7 @@ func NewRouterWithLogger(logger *zap.SugaredLogger) http.Handler {
 	equiptrust.RegisterRoutes(r)
 	sensorvault.RegisterRoutes(r)
 	permitgrid.RegisterRoutes(r)
+	flowgrid.RegisterRoutes(r)
 	traceboard.RegisterRoutes(r)
 
 	r.Use(handlers.MetricsMiddleware)


### PR DESCRIPTION
## Summary
- add FlowGrid module for matching tasks to available workers
- wire FlowGrid into main init and router

## Testing
- `go fmt ./...`
- `GOTOOLCHAIN=local go build ./...` *(fails: access denied to storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6863f9e21d30832db003896240e1b63d