### PR TITLE
Add CorePad++ multimedia notes support

### DIFF
--- a/backend/internal/corepad/handler/notes.go
+++ b/backend/internal/corepad/handler/notes.go
@@ -13,6 +13,7 @@ type NoteRequest struct {
 	Content string   `json:"content"`
 	Author  string   `json:"author"`
 	Tags    []string `json:"tags"`
+	Media   []string `json:"media"`
 }
 
 // POST /corepad/notes
@@ -23,7 +24,7 @@ func CreateNoteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	note, err := usecase.CreateNote(req.Content, req.Author, req.Tags)
+	note, err := usecase.CreateNote(req.Content, req.Author, req.Tags, req.Media)
 	if err != nil {
 		http.Error(w, "Could not create note", http.StatusInternalServerError)
 		return

--- a/backend/internal/corepad/model/note.go
+++ b/backend/internal/corepad/model/note.go
@@ -7,9 +7,12 @@ import (
 )
 
 type Note struct {
-	ID        primitive.ObjectID `bson:"_id,omitempty" json:"id"`
-	Content   string             `json:"content" bson:"content"`
-	Author    string             `json:"author" bson:"author"`
-	Tags      []string           `json:"tags" bson:"tags"`
-	Timestamp time.Time          `json:"timestamp" bson:"timestamp"`
+	ID            primitive.ObjectID `bson:"_id,omitempty" json:"id"`
+	Content       string             `json:"content" bson:"content"`
+	Author        string             `json:"author" bson:"author"`
+	Tags          []string           `json:"tags" bson:"tags"`
+	Timestamp     time.Time          `json:"timestamp" bson:"timestamp"`
+	Media         []string           `json:"media,omitempty" bson:"media,omitempty"`
+	PriorityScore float64            `json:"priority_score,omitempty" bson:"priority_score,omitempty"`
+	SuggestAction bool               `json:"suggest_action,omitempty" bson:"suggest_action,omitempty"`
 }

--- a/backend/internal/corepad/usecase/note_usecase.go
+++ b/backend/internal/corepad/usecase/note_usecase.go
@@ -5,12 +5,15 @@ import (
 	"github.com/elkarto91/operary/internal/corepad/repo"
 )
 
-func CreateNote(content, author string, tags []string) (model.Note, error) {
+func CreateNote(content, author string, tags, media []string) (model.Note, error) {
 	note := model.Note{
 		Content: content,
 		Author:  author,
 		Tags:    tags,
+		Media:   media,
 	}
+	note.PriorityScore = DetectPriority(content)
+	note.SuggestAction = ShouldEscalate(content)
 	return repo.SaveNote(note)
 }
 

--- a/backend/internal/corepad/usecase/suggestion.go
+++ b/backend/internal/corepad/usecase/suggestion.go
@@ -1,0 +1,22 @@
+package usecase
+
+import "strings"
+
+// DetectPriority assigns a basic priority score based on keywords.
+func DetectPriority(content string) float64 {
+	c := strings.ToLower(content)
+	switch {
+	case strings.Contains(c, "urgent"):
+		return 0.9
+	case strings.Contains(c, "low"):
+		return 0.2
+	default:
+		return 0.5
+	}
+}
+
+// ShouldEscalate recommends escalation based on simple rules.
+func ShouldEscalate(content string) bool {
+	c := strings.ToLower(content)
+	return strings.Contains(c, "escalate") || strings.Contains(c, "critical")
+}

--- a/scripts/Readme.md
+++ b/scripts/Readme.md
@@ -8,7 +8,8 @@ This directory contains scripts to test core Operary flows using the public REST
 
 | Script | Description |
 |--------|-------------|
-| `sim_shift_test.go` | Starts a shift, creates tasks, updates statuses, and closes the shift — all via API calls  
+| `sim_shift_test.go` | Starts a shift, creates tasks, updates statuses, and closes the shift — all via API calls
+| `sample_media_upload.go` | Uploads a note with example media attachment
 | *(future)* | Add escalation test, webhook trigger test, or error response test
 
 ---
@@ -38,6 +39,7 @@ This simulation performs:
 ```bash
 cd scripts/
 go run sim_shift_test.go
+go run sample_media_upload.go # send a note with media
 
 
 Expected Output

--- a/scripts/sample_media_upload.go
+++ b/scripts/sample_media_upload.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const apiBase = "http://localhost:8080/v1"
+const orgToken = "your-org-token-here"
+
+func main() {
+	note := map[string]interface{}{
+		"content": "Pump status photo attached",
+		"author":  "tester",
+		"tags":    []string{"shift-a"},
+		"media":   []string{"https://example.com/photo.jpg"},
+	}
+	data, _ := json.Marshal(note)
+	req, _ := http.NewRequest("POST", apiBase+"/corepad/notes", bytes.NewBuffer(data))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Org-Token", orgToken)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	fmt.Println(string(body))
+}


### PR DESCRIPTION
## Summary
- extend CorePad note model with media and suggestion fields
- detect priority and escalation via new suggestion logic
- accept media field in note handler
- add sample script for media note upload
- update script docs

## Testing
- `go build ./...` *(fails: Forbidden storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6863fb3c4494832d9f420d766ee21564