### PR TITLE
Add suggestion usecase with ML-style stubs

### DIFF
--- a/backend/internal/corepad/usecase/suggestion.go
+++ b/backend/internal/corepad/usecase/suggestion.go
@@ -1,0 +1,29 @@
+package usecase
+
+import (
+	"strings"
+)
+
+// DetectPriority assigns a fake priority score based on keyword presence
+func DetectPriority(content string) float64 {
+	content = strings.ToLower(content)
+	if strings.Contains(content, "urgent") || strings.Contains(content, "immediate") {
+		return 0.9
+	}
+	if strings.Contains(content, "warning") {
+		return 0.7
+	}
+	return 0.3
+}
+
+// ShouldEscalate returns true if content matches fake escalation keywords
+func ShouldEscalate(content string) bool {
+	content = strings.ToLower(content)
+	keywords := []string{"fail", "accident", "shutdown", "hazard", "breach"}
+	for _, word := range keywords {
+		if strings.Contains(content, word) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- implement new suggestion.go for corepad usecase
- provide simple keyword-based logic for priority and escalation

## Testing
- `go vet ./...` *(fails: Forbidden storage.googleapis.com)*
- `go test ./...` *(fails: Forbidden storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6863fc2be444832db4351b21a81981dc