### PR TITLE
Add TrainOps self-learning module

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Operary is organized into small Go packages under `backend/internal`. Each packa
 - **PermitGrid** – permit-to-work requests
 - **EquipTrust** – equipment ledger
 - **SensorVault** – machine event storage
+- **TrainOps** – self-learning operational intelligence
 A full list of functions is provided in [docs/overview.md](docs/overview.md).
 
 ---

--- a/api_spec/trainops.yaml
+++ b/api_spec/trainops.yaml
@@ -1,0 +1,88 @@
+openapi: 3.0.0
+info:
+  title: TrainOps API
+  version: 1.0.0
+  description: API for self-learning operational intelligence
+
+paths:
+  /trainops/ingest:
+    post:
+      summary: Ingest training sample
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrainingSampleRequest'
+      responses:
+        '200':
+          description: Sample stored
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingSample'
+
+  /trainops/predictions:
+    get:
+      summary: List stored samples
+      responses:
+        '200':
+          description: Samples list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrainingSample'
+
+  /trainops/feedback:
+    post:
+      summary: Provide feedback on a sample
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [id, feedback]
+              properties:
+                id:
+                  type: string
+                feedback:
+                  type: string
+      responses:
+        '200':
+          description: Updated sample
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrainingSample'
+
+components:
+  schemas:
+    TrainingSampleRequest:
+      type: object
+      required: [source, content]
+      properties:
+        source:
+          type: string
+        content:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        outcome:
+          type: string
+    TrainingSample:
+      allOf:
+        - $ref: '#/components/schemas/TrainingSampleRequest'
+        - type: object
+          properties:
+            id:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+            feedback:
+              type: string

--- a/backend/internal/handlers/metrics.go
+++ b/backend/internal/handlers/metrics.go
@@ -111,6 +111,13 @@ var (
 			Help: "Total number of equipment returns",
 		},
 	)
+
+	TrainOpsSamplesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "trainops_samples_total",
+			Help: "Total training samples ingested",
+		},
+	)
 )
 
 func init() {
@@ -124,4 +131,5 @@ func init() {
 	prometheus.MustRegister(PermitGridRejections)
 	prometheus.MustRegister(EquipTrustCheckouts)
 	prometheus.MustRegister(EquipTrustReturns)
+	prometheus.MustRegister(TrainOpsSamplesTotal)
 }

--- a/backend/internal/trainops/handler/trainops.go
+++ b/backend/internal/trainops/handler/trainops.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	metrics "github.com/elkarto91/operary/internal/handlers"
+	"github.com/elkarto91/operary/internal/trainops/usecase"
+)
+
+func IngestData(w http.ResponseWriter, r *http.Request) {
+	var req usecase.IngestRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	sample, err := usecase.Ingest(req)
+	if err != nil {
+		http.Error(w, "Failed to ingest", http.StatusInternalServerError)
+		return
+	}
+	metrics.TrainOpsSamplesTotal.Inc()
+	json.NewEncoder(w).Encode(sample)
+}
+
+func ListPredictions(w http.ResponseWriter, r *http.Request) {
+	samples, err := usecase.List()
+	if err != nil {
+		http.Error(w, "Failed to list", http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(samples)
+}
+
+func ProvideFeedback(w http.ResponseWriter, r *http.Request) {
+	var payload struct {
+		ID       string `json:"id"`
+		Feedback string `json:"feedback"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	sample, err := usecase.AddFeedback(payload.ID, payload.Feedback)
+	if err != nil {
+		http.Error(w, "Failed to update", http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(sample)
+}

--- a/backend/internal/trainops/model/sample.go
+++ b/backend/internal/trainops/model/sample.go
@@ -1,0 +1,18 @@
+package model
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// TrainingSample represents one labeled piece of historical content.
+type TrainingSample struct {
+	ID        primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Source    string             `json:"source"`
+	Content   string             `json:"content"`
+	Tags      []string           `json:"tags"`
+	Outcome   string             `json:"outcome,omitempty"`
+	Feedback  *string            `json:"feedback,omitempty"`
+	CreatedAt time.Time          `json:"created_at"`
+}

--- a/backend/internal/trainops/repo/sample_repository.go
+++ b/backend/internal/trainops/repo/sample_repository.go
@@ -1,0 +1,42 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/elkarto91/operary/internal/trainops/model"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var collection *mongo.Collection
+
+func InitMongoCollection(db *mongo.Database) {
+	collection = db.Collection("training_samples")
+}
+
+func Save(sample model.TrainingSample) (model.TrainingSample, error) {
+	sample.ID = primitive.NewObjectID()
+	sample.CreatedAt = time.Now()
+	_, err := collection.InsertOne(context.Background(), sample)
+	return sample, err
+}
+
+func List() ([]model.TrainingSample, error) {
+	cursor, err := collection.Find(context.Background(), bson.M{})
+	if err != nil {
+		return nil, err
+	}
+
+	var results []model.TrainingSample
+	err = cursor.All(context.Background(), &results)
+	return results, err
+}
+
+func UpdateFeedback(id primitive.ObjectID, fb string) (model.TrainingSample, error) {
+	var updated model.TrainingSample
+	update := bson.M{"$set": bson.M{"feedback": fb}}
+	err := collection.FindOneAndUpdate(context.Background(), bson.M{"_id": id}, update).Decode(&updated)
+	return updated, err
+}

--- a/backend/internal/trainops/trainops.go
+++ b/backend/internal/trainops/trainops.go
@@ -1,0 +1,20 @@
+package trainops
+
+import (
+	"github.com/elkarto91/operary/internal/trainops/handler"
+	"github.com/elkarto91/operary/internal/trainops/repo"
+	"github.com/go-chi/chi/v5"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func Init(db *mongo.Database) {
+	repo.InitMongoCollection(db)
+}
+
+func RegisterRoutes(r chi.Router) {
+	r.Route("/trainops", func(r chi.Router) {
+		r.Post("/ingest", handler.IngestData)
+		r.Get("/predictions", handler.ListPredictions)
+		r.Post("/feedback", handler.ProvideFeedback)
+	})
+}

--- a/backend/internal/trainops/usecase/sample_usecase.go
+++ b/backend/internal/trainops/usecase/sample_usecase.go
@@ -1,0 +1,37 @@
+package usecase
+
+import (
+	"github.com/elkarto91/operary/internal/trainops/model"
+	"github.com/elkarto91/operary/internal/trainops/repo"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// IngestRequest defines the payload required to create a TrainingSample.
+type IngestRequest struct {
+	Source  string   `json:"source"`
+	Content string   `json:"content"`
+	Tags    []string `json:"tags"`
+	Outcome string   `json:"outcome,omitempty"`
+}
+
+func Ingest(req IngestRequest) (model.TrainingSample, error) {
+	sample := model.TrainingSample{
+		Source:  req.Source,
+		Content: req.Content,
+		Tags:    req.Tags,
+		Outcome: req.Outcome,
+	}
+	return repo.Save(sample)
+}
+
+func List() ([]model.TrainingSample, error) {
+	return repo.List()
+}
+
+func AddFeedback(id string, fb string) (model.TrainingSample, error) {
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return model.TrainingSample{}, err
+	}
+	return repo.UpdateFeedback(objID, fb)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elkarto91/operary/internal/sensorvault"
 	"github.com/elkarto91/operary/internal/services"
 	"github.com/elkarto91/operary/internal/traceboard"
+	"github.com/elkarto91/operary/internal/trainops"
 	"github.com/elkarto91/operary/router"
 	"github.com/joho/godotenv"
 	"go.uber.org/zap"
@@ -40,6 +41,7 @@ func main() {
 	traceboard.Init(db)
 	equiptrust.Init(db)
 	sensorvault.Init(db)
+	trainops.Init(db)
 
 	services.StartNotificationService(sugar)
 

--- a/backend/router/routes.go
+++ b/backend/router/routes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elkarto91/operary/internal/permitgrid"
 	"github.com/elkarto91/operary/internal/sensorvault"
 	"github.com/elkarto91/operary/internal/traceboard"
+	"github.com/elkarto91/operary/internal/trainops"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -32,6 +33,7 @@ func NewRouterWithLogger(logger *zap.SugaredLogger) http.Handler {
 	auditsync.RegisterRoutes(r)
 	equiptrust.RegisterRoutes(r)
 	sensorvault.RegisterRoutes(r)
+	trainops.RegisterRoutes(r)
 	permitgrid.RegisterRoutes(r)
 	flowgrid.RegisterRoutes(r)
 	traceboard.RegisterRoutes(r)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -97,6 +97,24 @@ Recording machine events and telemetry.
 - `Save(SensorEvent)`
 - `List()`
 
+## TrainOps
+Self-learning engine that stores tagged notes and feedback.
+
+**Main handlers**
+- `IngestData` – POST `/trainops/ingest`
+- `ListPredictions` – GET `/trainops/predictions`
+- `ProvideFeedback` – POST `/trainops/feedback`
+
+**Usecase layer**
+- `Ingest(request)`
+- `List()`
+- `AddFeedback(id, fb)`
+
+**Repository layer**
+- `Save(TrainingSample)`
+- `List()`
+- `UpdateFeedback(id, fb)`
+
 ## Shared Models
 Core task and shift logic lives under `internal/models`:
 - `Task` with functions `CreateTask`, `GetAllTasks`, `UpdateTask`, `GetTasksByTimeRange`.

--- a/docs/phase1_modules.md
+++ b/docs/phase1_modules.md
@@ -13,6 +13,7 @@ This document provides an extended reference for all Operary modules delivered i
 | PermitGrid | Manage permits and PTWs | ✅ Done |
 | EquipTrust | Track asset/equipment lifecycle | ✅ Done |
 | SensorVault | Log sensor alerts, anomalies | ✅ Done |
+| TrainOps | Self-learning operational intelligence | ✅ Done |
 | TraceBoard | RCA and fault tree tracking | ✅ Done |
 | FlowGrid | Auto-assign shifts using skill matching | ✅ Done |
 | CorePad++ | Multimedia notes & GPT-style escalations | ✅ Done |
@@ -78,7 +79,14 @@ Stores sensor anomalies and telemetry events.
 
 Events are saved in `sensor_events` with optional links to tasks or audits.
 
-## 8. TraceBoard
+## 8. TrainOps
+Collects tagged operational notes for future model training.
+
+- `POST /trainops/ingest` – add a training sample.
+- `GET /trainops/predictions` – list stored samples.
+- `POST /trainops/feedback` – submit feedback on a prediction.
+
+## 9. TraceBoard
 Root cause analysis and incident tracking.
 
 - `POST /traceboard/incidents` – submit an incident report.
@@ -88,7 +96,7 @@ Root cause analysis and incident tracking.
 
 Reports in `traceboard_incidents` can later feed PDF exports and fault‑tree visualizations.
 
-## 9. FlowGrid
+## 10. FlowGrid
 Skill matching engine for shift scheduling.
 
 - `POST /flowgrid/match-skills` – return best worker assignments based on required skills.
@@ -96,7 +104,7 @@ Skill matching engine for shift scheduling.
 
 The module is stateless today but sets the foundation for automated scheduling.
 
-## 10. CorePad++
+## 11. CorePad++
 An extension of CorePad to support multimedia attachments and GPT‑style escalation summaries. Implementation will build upon CorePad handlers and is scoped for future enhancement.
 
 ---


### PR DESCRIPTION
## Summary
- implement TrainOps backend package for training samples
- register new `/trainops` routes
- expose metric `trainops_samples_total`
- document TrainOps module and API

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686400c98b04832db99c2ec15478c705