### PR TITLE
Add SupplyMesh supplier tracking module

### DIFF
--- a/api_spec/supplymesh.yaml
+++ b/api_spec/supplymesh.yaml
@@ -1,0 +1,140 @@
+openapi: 3.0.0
+info:
+  title: SupplyMesh API
+  version: 1.0.0
+  description: API for tracking suppliers and deliveries in Operary
+paths:
+  /supplymesh/suppliers:
+    post:
+      summary: Add a new supplier
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SupplierRequest'
+      responses:
+        '201':
+          description: Supplier created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Supplier'
+    get:
+      summary: List all suppliers
+      responses:
+        '200':
+          description: Supplier list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Supplier'
+  /supplymesh/deliveries:
+    post:
+      summary: Log an expected delivery
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeliveryRequest'
+      responses:
+        '201':
+          description: Delivery logged
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Delivery'
+    get:
+      summary: List deliveries
+      responses:
+        '200':
+          description: Delivery list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Delivery'
+  /supplymesh/escalate:
+    post:
+      summary: Escalate an issue
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EscalationRequest'
+      responses:
+        '201':
+          description: Issue escalated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Escalation'
+components:
+  schemas:
+    SupplierRequest:
+      type: object
+      required: [name, sla]
+      properties:
+        name:
+          type: string
+        sla:
+          type: integer
+    Supplier:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        sla:
+          type: integer
+    DeliveryRequest:
+      type: object
+      required: [supplier_id, item, expected_date]
+      properties:
+        supplier_id:
+          type: string
+        item:
+          type: string
+        expected_date:
+          type: string
+          format: date-time
+    Delivery:
+      type: object
+      properties:
+        id:
+          type: string
+        supplier_id:
+          type: string
+        item:
+          type: string
+        expected_date:
+          type: string
+          format: date-time
+        delivered:
+          type: boolean
+    EscalationRequest:
+      type: object
+      required: [delivery_id, reason]
+      properties:
+        delivery_id:
+          type: string
+        reason:
+          type: string
+    Escalation:
+      type: object
+      properties:
+        id:
+          type: string
+        delivery_id:
+          type: string
+        reason:
+          type: string
+        timestamp:
+          type: string
+          format: date-time

--- a/backend/internal/supplymesh/handler/handlers.go
+++ b/backend/internal/supplymesh/handler/handlers.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/elkarto91/operary/internal/supplymesh/usecase"
+)
+
+func AddSupplier(w http.ResponseWriter, r *http.Request) {
+	var req usecase.SupplierRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	supplier, err := usecase.AddSupplier(req)
+	if err != nil {
+		http.Error(w, "Failed to save supplier", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(supplier)
+}
+
+func ListSuppliers(w http.ResponseWriter, r *http.Request) {
+	suppliers, err := usecase.ListSuppliers()
+	if err != nil {
+		http.Error(w, "Failed to retrieve suppliers", http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(suppliers)
+}
+
+func AddDelivery(w http.ResponseWriter, r *http.Request) {
+	var req usecase.DeliveryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	delivery, err := usecase.AddDelivery(req)
+	if err != nil {
+		http.Error(w, "Failed to save delivery", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(delivery)
+}
+
+func ListDeliveries(w http.ResponseWriter, r *http.Request) {
+	deliveries, err := usecase.ListDeliveries()
+	if err != nil {
+		http.Error(w, "Failed to retrieve deliveries", http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(deliveries)
+}
+
+func EscalateIssue(w http.ResponseWriter, r *http.Request) {
+	var req usecase.EscalationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	escalation, err := usecase.Escalate(req)
+	if err != nil {
+		http.Error(w, "Failed to escalate issue", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(escalation)
+}

--- a/backend/internal/supplymesh/model/models.go
+++ b/backend/internal/supplymesh/model/models.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type Supplier struct {
+	ID   primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	Name string             `json:"name" bson:"name"`
+	SLA  int                `json:"sla" bson:"sla"`
+}
+
+type Delivery struct {
+	ID           primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	SupplierID   primitive.ObjectID `json:"supplier_id" bson:"supplier_id"`
+	Item         string             `json:"item" bson:"item"`
+	ExpectedDate time.Time          `json:"expected_date" bson:"expected_date"`
+	Delivered    bool               `json:"delivered" bson:"delivered"`
+}
+
+type Escalation struct {
+	ID         primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	DeliveryID primitive.ObjectID `json:"delivery_id" bson:"delivery_id"`
+	Reason     string             `json:"reason" bson:"reason"`
+	Timestamp  time.Time          `json:"timestamp" bson:"timestamp"`
+}

--- a/backend/internal/supplymesh/repo/repository.go
+++ b/backend/internal/supplymesh/repo/repository.go
@@ -1,0 +1,61 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/elkarto91/operary/internal/supplymesh/model"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var suppliers *mongo.Collection
+var deliveries *mongo.Collection
+var escalations *mongo.Collection
+
+func InitMongoCollections(db *mongo.Database) {
+	suppliers = db.Collection("suppliers")
+	deliveries = db.Collection("deliveries")
+	escalations = db.Collection("escalations")
+}
+
+func SaveSupplier(s model.Supplier) (model.Supplier, error) {
+	s.ID = primitive.NewObjectID()
+	_, err := suppliers.InsertOne(context.Background(), s)
+	return s, err
+}
+
+func ListSuppliers() ([]model.Supplier, error) {
+	cursor, err := suppliers.Find(context.Background(), bson.M{})
+	if err != nil {
+		return nil, err
+	}
+	var results []model.Supplier
+	err = cursor.All(context.Background(), &results)
+	return results, err
+}
+
+func SaveDelivery(d model.Delivery) (model.Delivery, error) {
+	d.ID = primitive.NewObjectID()
+	d.Delivered = false
+	_, err := deliveries.InsertOne(context.Background(), d)
+	return d, err
+}
+
+func ListDeliveries() ([]model.Delivery, error) {
+	cursor, err := deliveries.Find(context.Background(), bson.M{})
+	if err != nil {
+		return nil, err
+	}
+	var results []model.Delivery
+	err = cursor.All(context.Background(), &results)
+	return results, err
+}
+
+func SaveEscalation(e model.Escalation) (model.Escalation, error) {
+	e.ID = primitive.NewObjectID()
+	e.Timestamp = time.Now()
+	_, err := escalations.InsertOne(context.Background(), e)
+	return e, err
+}

--- a/backend/internal/supplymesh/supplymesh.go
+++ b/backend/internal/supplymesh/supplymesh.go
@@ -1,0 +1,22 @@
+package supplymesh
+
+import (
+	"github.com/elkarto91/operary/internal/supplymesh/handler"
+	"github.com/elkarto91/operary/internal/supplymesh/repo"
+	"github.com/go-chi/chi/v5"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func Init(db *mongo.Database) {
+	repo.InitMongoCollections(db)
+}
+
+func RegisterRoutes(r chi.Router) {
+	r.Route("/supplymesh", func(r chi.Router) {
+		r.Post("/suppliers", handler.AddSupplier)
+		r.Get("/suppliers", handler.ListSuppliers)
+		r.Post("/deliveries", handler.AddDelivery)
+		r.Get("/deliveries", handler.ListDeliveries)
+		r.Post("/escalate", handler.EscalateIssue)
+	})
+}

--- a/backend/internal/supplymesh/usecase/usecase.go
+++ b/backend/internal/supplymesh/usecase/usecase.go
@@ -1,0 +1,60 @@
+package usecase
+
+import (
+	"time"
+
+	"github.com/elkarto91/operary/internal/supplymesh/model"
+	"github.com/elkarto91/operary/internal/supplymesh/repo"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type SupplierRequest struct {
+	Name string `json:"name"`
+	SLA  int    `json:"sla"`
+}
+
+type DeliveryRequest struct {
+	SupplierID   string `json:"supplier_id"`
+	Item         string `json:"item"`
+	ExpectedDate string `json:"expected_date"`
+}
+
+type EscalationRequest struct {
+	DeliveryID string `json:"delivery_id"`
+	Reason     string `json:"reason"`
+}
+
+func AddSupplier(req SupplierRequest) (model.Supplier, error) {
+	supplier := model.Supplier{Name: req.Name, SLA: req.SLA}
+	return repo.SaveSupplier(supplier)
+}
+
+func ListSuppliers() ([]model.Supplier, error) {
+	return repo.ListSuppliers()
+}
+
+func AddDelivery(req DeliveryRequest) (model.Delivery, error) {
+	supID, err := primitive.ObjectIDFromHex(req.SupplierID)
+	if err != nil {
+		return model.Delivery{}, err
+	}
+	expected, err := time.Parse(time.RFC3339, req.ExpectedDate)
+	if err != nil {
+		return model.Delivery{}, err
+	}
+	d := model.Delivery{SupplierID: supID, Item: req.Item, ExpectedDate: expected}
+	return repo.SaveDelivery(d)
+}
+
+func ListDeliveries() ([]model.Delivery, error) {
+	return repo.ListDeliveries()
+}
+
+func Escalate(req EscalationRequest) (model.Escalation, error) {
+	dID, err := primitive.ObjectIDFromHex(req.DeliveryID)
+	if err != nil {
+		return model.Escalation{}, err
+	}
+	e := model.Escalation{DeliveryID: dID, Reason: req.Reason}
+	return repo.SaveEscalation(e)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elkarto91/operary/internal/permitgrid"
 	"github.com/elkarto91/operary/internal/sensorvault"
 	"github.com/elkarto91/operary/internal/services"
+	"github.com/elkarto91/operary/internal/supplymesh"
 	"github.com/elkarto91/operary/internal/traceboard"
 	"github.com/elkarto91/operary/internal/trainops"
 	"github.com/elkarto91/operary/router"
@@ -42,6 +43,7 @@ func main() {
 	equiptrust.Init(db)
 	sensorvault.Init(db)
 	trainops.Init(db)
+	supplymesh.Init(db)
 
 	services.StartNotificationService(sugar)
 

--- a/backend/router/routes.go
+++ b/backend/router/routes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elkarto91/operary/internal/opsmirror"
 	"github.com/elkarto91/operary/internal/permitgrid"
 	"github.com/elkarto91/operary/internal/sensorvault"
+	"github.com/elkarto91/operary/internal/supplymesh"
 	"github.com/elkarto91/operary/internal/traceboard"
 	"github.com/elkarto91/operary/internal/trainops"
 	"github.com/go-chi/chi/v5"
@@ -35,6 +36,7 @@ func NewRouterWithLogger(logger *zap.SugaredLogger) http.Handler {
 	sensorvault.RegisterRoutes(r)
 	trainops.RegisterRoutes(r)
 	permitgrid.RegisterRoutes(r)
+	supplymesh.RegisterRoutes(r)
 	flowgrid.RegisterRoutes(r)
 	traceboard.RegisterRoutes(r)
 


### PR DESCRIPTION
## Summary
- create new SupplyMesh module for vendors and deliveries
- implement suppliers, deliveries and escalation endpoints
- wire module into router and server startup
- document API in `api_spec/supplymesh.yaml`

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68640311c38c832da6a0e97175495fa8