### PR TITLE
Add TwinBoard digital twin module

### DIFF
--- a/backend/internal/twinboard/handler/twin.go
+++ b/backend/internal/twinboard/handler/twin.go
@@ -1,0 +1,60 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/elkarto91/operary/internal/twinboard/usecase"
+)
+
+// TriggerSnapshot handles POST /twinboard/snapshot to capture the current state.
+func TriggerSnapshot(w http.ResponseWriter, r *http.Request) {
+	snap, err := usecase.GenerateSnapshot()
+	if err != nil {
+		http.Error(w, "Failed to generate snapshot", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(snap)
+}
+
+// GetLiveState returns the most recently generated snapshot.
+func GetLiveState(w http.ResponseWriter, r *http.Request) {
+	snap, err := usecase.GetLiveSnapshot()
+	if err != nil {
+		http.Error(w, "No snapshot available", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(snap)
+}
+
+// GetHistory returns snapshots between provided start and end times.
+func GetHistory(w http.ResponseWriter, r *http.Request) {
+	startStr := r.URL.Query().Get("start")
+	endStr := r.URL.Query().Get("end")
+
+	start, err := time.Parse(time.RFC3339, startStr)
+	if err != nil {
+		http.Error(w, "invalid start", http.StatusBadRequest)
+		return
+	}
+	end, err := time.Parse(time.RFC3339, endStr)
+	if err != nil {
+		http.Error(w, "invalid end", http.StatusBadRequest)
+		return
+	}
+
+	snaps, err := usecase.GetHistory(start, end)
+	if err != nil {
+		http.Error(w, "failed to fetch history", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(snaps)
+}

--- a/backend/internal/twinboard/model/twin.go
+++ b/backend/internal/twinboard/model/twin.go
@@ -1,0 +1,13 @@
+package model
+
+import "time"
+
+// TwinSnapshot represents an operational state at a given moment.
+type TwinSnapshot struct {
+	Timestamp     time.Time         `json:"timestamp" bson:"timestamp"`
+	ActiveWorkers []string          `json:"active_workers" bson:"active_workers"`
+	ActiveTasks   []string          `json:"active_tasks" bson:"active_tasks"`
+	EquipmentUsed map[string]string `json:"equipment_used" bson:"equipment_used"`
+	Warnings      []string          `json:"warnings" bson:"warnings"`
+	StatusScore   float64           `json:"status_score" bson:"status_score"`
+}

--- a/backend/internal/twinboard/repo/snapshot_repository.go
+++ b/backend/internal/twinboard/repo/snapshot_repository.go
@@ -1,0 +1,47 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/elkarto91/operary/internal/twinboard/model"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var collection *mongo.Collection
+
+// InitMongoCollection stores the MongoDB collection handle.
+func InitMongoCollection(db *mongo.Database) {
+	collection = db.Collection("twin_snapshots")
+}
+
+// SaveSnapshot inserts a snapshot into MongoDB.
+func SaveSnapshot(s model.TwinSnapshot) (model.TwinSnapshot, error) {
+	if s.Timestamp.IsZero() {
+		s.Timestamp = time.Now()
+	}
+	_, err := collection.InsertOne(context.Background(), s)
+	return s, err
+}
+
+// GetLatest returns the most recent snapshot.
+func GetLatest() (model.TwinSnapshot, error) {
+	opts := options.FindOne().SetSort(bson.M{"timestamp": -1})
+	var snap model.TwinSnapshot
+	err := collection.FindOne(context.Background(), bson.M{}, opts).Decode(&snap)
+	return snap, err
+}
+
+// ListRange returns snapshots between start and end timestamps.
+func ListRange(start, end time.Time) ([]model.TwinSnapshot, error) {
+	filter := bson.M{"timestamp": bson.M{"$gte": start, "$lte": end}}
+	cursor, err := collection.Find(context.Background(), filter)
+	if err != nil {
+		return nil, err
+	}
+	var results []model.TwinSnapshot
+	err = cursor.All(context.Background(), &results)
+	return results, err
+}

--- a/backend/internal/twinboard/twinboard.go
+++ b/backend/internal/twinboard/twinboard.go
@@ -1,0 +1,22 @@
+package twinboard
+
+import (
+	"github.com/elkarto91/operary/internal/twinboard/handler"
+	"github.com/elkarto91/operary/internal/twinboard/repo"
+	"github.com/go-chi/chi/v5"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Init sets up the MongoDB collection used for storing snapshots.
+func Init(db *mongo.Database) {
+	repo.InitMongoCollection(db)
+}
+
+// RegisterRoutes exposes HTTP endpoints for the TwinBoard module.
+func RegisterRoutes(r chi.Router) {
+	r.Route("/twinboard", func(r chi.Router) {
+		r.Post("/snapshot", handler.TriggerSnapshot)
+		r.Get("/live", handler.GetLiveState)
+		r.Get("/history", handler.GetHistory)
+	})
+}

--- a/backend/internal/twinboard/usecase/twin.go
+++ b/backend/internal/twinboard/usecase/twin.go
@@ -1,0 +1,69 @@
+package usecase
+
+import (
+	equip "github.com/elkarto91/operary/internal/equiptrust/usecase"
+	"github.com/elkarto91/operary/internal/models"
+	"github.com/elkarto91/operary/internal/opsmirror/usecase"
+	"github.com/elkarto91/operary/internal/twinboard/model"
+	"github.com/elkarto91/operary/internal/twinboard/repo"
+	"time"
+)
+
+// GenerateSnapshot reads current system state and stores a TwinSnapshot.
+func GenerateSnapshot() (model.TwinSnapshot, error) {
+	tasks, _ := models.GetAllTasks()
+
+	var activeTasks []string
+	workerSet := make(map[string]struct{})
+	for _, t := range tasks {
+		activeTasks = append(activeTasks, t.ID)
+		if t.AssignedTo != "" {
+			workerSet[t.AssignedTo] = struct{}{}
+		}
+	}
+	var activeWorkers []string
+	for w := range workerSet {
+		activeWorkers = append(activeWorkers, w)
+	}
+
+	ledger, _ := equip.ListLedger()
+	equipment := make(map[string]string)
+	for _, e := range ledger {
+		if e.ReturnedAt == nil {
+			equipment[e.EquipmentID] = e.Purpose
+		}
+	}
+
+	statuses, _ := usecase.FetchStatuses()
+	var warnings []string
+	for _, s := range statuses {
+		if s.State == "WARN" {
+			warnings = append(warnings, s.System)
+		}
+	}
+	score := 1.0
+	if len(statuses) > 0 {
+		score = 1.0 - float64(len(warnings))/float64(len(statuses))
+	}
+
+	snap := model.TwinSnapshot{
+		Timestamp:     time.Now(),
+		ActiveWorkers: activeWorkers,
+		ActiveTasks:   activeTasks,
+		EquipmentUsed: equipment,
+		Warnings:      warnings,
+		StatusScore:   score,
+	}
+	saved, err := repo.SaveSnapshot(snap)
+	return saved, err
+}
+
+// GetLiveSnapshot returns the most recent TwinSnapshot.
+func GetLiveSnapshot() (model.TwinSnapshot, error) {
+	return repo.GetLatest()
+}
+
+// GetHistory returns snapshots between start and end time.
+func GetHistory(start, end time.Time) ([]model.TwinSnapshot, error) {
+	return repo.ListRange(start, end)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elkarto91/operary/internal/services"
 	"github.com/elkarto91/operary/internal/traceboard"
 	"github.com/elkarto91/operary/internal/trainops"
+	"github.com/elkarto91/operary/internal/twinboard"
 	"github.com/elkarto91/operary/router"
 	"github.com/joho/godotenv"
 	"go.uber.org/zap"
@@ -42,6 +43,7 @@ func main() {
 	equiptrust.Init(db)
 	sensorvault.Init(db)
 	trainops.Init(db)
+	twinboard.Init(db)
 
 	services.StartNotificationService(sugar)
 

--- a/backend/router/routes.go
+++ b/backend/router/routes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elkarto91/operary/internal/sensorvault"
 	"github.com/elkarto91/operary/internal/traceboard"
 	"github.com/elkarto91/operary/internal/trainops"
+	"github.com/elkarto91/operary/internal/twinboard"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -37,6 +38,7 @@ func NewRouterWithLogger(logger *zap.SugaredLogger) http.Handler {
 	permitgrid.RegisterRoutes(r)
 	flowgrid.RegisterRoutes(r)
 	traceboard.RegisterRoutes(r)
+	twinboard.RegisterRoutes(r)
 
 	r.Use(handlers.MetricsMiddleware)
 	r.Get("/v1/metrics", handlers.MetricsHandler)


### PR DESCRIPTION
## Summary
- create new TwinBoard module with snapshot model and Mongo repo
- add handlers and use cases for generating and retrieving snapshots
- wire TwinBoard into router and main initialization

## Testing
- `go build ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6864047a6424832dba17d170b6314775