### PR TITLE
Add integrations service for webhook/email

### DIFF
--- a/api_spec/integrations.yaml
+++ b/api_spec/integrations.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.0
+info:
+  title: Integrations API
+  version: 1.0.0
+  description: API for sending outbound webhooks and emails
+paths:
+  /integrations/webhook/send:
+    post:
+      summary: Send a custom HTTP webhook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookRequest'
+      responses:
+        '200':
+          description: Webhook triggered
+  /integrations/email/send:
+    post:
+      summary: Send an email using SMTP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailRequest'
+      responses:
+        '200':
+          description: Email sent
+components:
+  schemas:
+    WebhookRequest:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+        method:
+          type: string
+          default: POST
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+        payload:
+          type: object
+    EmailRequest:
+      type: object
+      required:
+        - to
+        - subject
+        - body
+      properties:
+        to:
+          type: array
+          items:
+            type: string
+        subject:
+          type: string
+        body:
+          type: string

--- a/backend/access-guide.md
+++ b/backend/access-guide.md
@@ -55,6 +55,10 @@ volumes:
 | `MONGO_URI`         | `mongodb://mongo:27017`      | MongoDB connection URI               |
 | `MONGO_DB`          | `operary_dev`                | Name of the MongoDB database         |
 | `ORG_TOKEN`         | `demo-org-token`             | Demo token for organizational scope  |
+| `SMTP_HOST`         | `smtp.example.com`           | SMTP server hostname for email       |
+| `SMTP_PORT`         | `587`                        | SMTP server port                     |
+| `SMTP_USER`         | `alert@example.com`          | SMTP username                        |
+| `SMTP_PASS`         | `yourpassword`               | SMTP password                        |
 
 All API calls must include the `X-Org-Token` header with this value.
 
@@ -78,6 +82,7 @@ You can import these files into Swagger Editor or Postman for API exploration:
 - `/api_spec/corepad.yaml`
 - `/api_spec/opsmirror.yaml`
 - `/api_spec/openapi.yaml` (core Operary APIs)
+- `/api_spec/integrations.yaml`
 
 ---
 

--- a/backend/internal/handlers/metrics.go
+++ b/backend/internal/handlers/metrics.go
@@ -118,6 +118,30 @@ var (
 			Help: "Total training samples ingested",
 		},
 	)
+	WebhookSuccess = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "webhook_success_total",
+			Help: "Total number of successful webhook calls",
+		},
+	)
+	WebhookFailures = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "webhook_failure_total",
+			Help: "Number of failed webhook calls",
+		},
+	)
+	EmailSuccess = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "email_success_total",
+			Help: "Total number of emails sent successfully",
+		},
+	)
+	EmailFailures = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "email_failure_total",
+			Help: "Number of failed email attempts",
+		},
+	)
 )
 
 func init() {
@@ -132,4 +156,8 @@ func init() {
 	prometheus.MustRegister(EquipTrustCheckouts)
 	prometheus.MustRegister(EquipTrustReturns)
 	prometheus.MustRegister(TrainOpsSamplesTotal)
+	prometheus.MustRegister(WebhookSuccess)
+	prometheus.MustRegister(WebhookFailures)
+	prometheus.MustRegister(EmailSuccess)
+	prometheus.MustRegister(EmailFailures)
 }

--- a/backend/internal/integrations/handler/integration.go
+++ b/backend/internal/integrations/handler/integration.go
@@ -1,0 +1,101 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/smtp"
+	"os"
+	"time"
+
+	metrics "github.com/elkarto91/operary/internal/handlers"
+	"github.com/elkarto91/operary/internal/integrations/model"
+)
+
+// SendWebhook handles POST /integrations/webhook/send and dispatches an HTTP webhook.
+func SendWebhook(w http.ResponseWriter, r *http.Request) {
+	var req model.WebhookRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	if req.URL == "" {
+		http.Error(w, "url is required", http.StatusBadRequest)
+		return
+	}
+
+	method := req.Method
+	if method == "" {
+		method = http.MethodPost
+	}
+
+	body, _ := json.Marshal(req.Payload)
+	httpReq, err := http.NewRequest(method, req.URL, bytes.NewBuffer(body))
+	if err != nil {
+		metrics.WebhookFailures.Inc()
+		http.Error(w, "Failed to create request", http.StatusInternalServerError)
+		return
+	}
+	for k, v := range req.Headers {
+		httpReq.Header.Set(k, v)
+	}
+	if httpReq.Header.Get("Content-Type") == "" {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		metrics.WebhookFailures.Inc()
+		http.Error(w, "Webhook call failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		metrics.WebhookSuccess.Inc()
+	} else {
+		metrics.WebhookFailures.Inc()
+	}
+
+	w.WriteHeader(resp.StatusCode)
+}
+
+// SendEmail handles POST /integrations/email/send and dispatches an email via SMTP.
+func SendEmail(w http.ResponseWriter, r *http.Request) {
+	var req model.EmailRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	if len(req.To) == 0 || req.Subject == "" {
+		http.Error(w, "missing fields", http.StatusBadRequest)
+		return
+	}
+
+	host := os.Getenv("SMTP_HOST")
+	port := os.Getenv("SMTP_PORT")
+	user := os.Getenv("SMTP_USER")
+	pass := os.Getenv("SMTP_PASS")
+
+	if host == "" || port == "" || user == "" || pass == "" {
+		http.Error(w, "SMTP not configured", http.StatusInternalServerError)
+		return
+	}
+
+	addr := fmt.Sprintf("%s:%s", host, port)
+	auth := smtp.PlainAuth("", user, pass, host)
+
+	msg := []byte(fmt.Sprintf("Subject: %s\r\n\r\n%s", req.Subject, req.Body))
+	if err := smtp.SendMail(addr, auth, user, req.To, msg); err != nil {
+		metrics.EmailFailures.Inc()
+		http.Error(w, "Failed to send email", http.StatusBadGateway)
+		return
+	}
+
+	metrics.EmailSuccess.Inc()
+	w.WriteHeader(http.StatusOK)
+}

--- a/backend/internal/integrations/integrations.go
+++ b/backend/internal/integrations/integrations.go
@@ -1,0 +1,20 @@
+package integrations
+
+import (
+	"github.com/elkarto91/operary/internal/integrations/handler"
+	"github.com/go-chi/chi/v5"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Init initializes resources for integrations. Currently no DB resources are used.
+func Init(db *mongo.Database) {
+	_ = db
+}
+
+// RegisterRoutes exposes integration related routes under /integrations.
+func RegisterRoutes(r chi.Router) {
+	r.Route("/integrations", func(r chi.Router) {
+		r.Post("/webhook/send", handler.SendWebhook)
+		r.Post("/email/send", handler.SendEmail)
+	})
+}

--- a/backend/internal/integrations/model/integration.go
+++ b/backend/internal/integrations/model/integration.go
@@ -1,0 +1,16 @@
+package model
+
+// WebhookRequest defines the payload for sending a webhook.
+type WebhookRequest struct {
+	URL     string            `json:"url"`
+	Method  string            `json:"method,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Payload map[string]any    `json:"payload,omitempty"`
+}
+
+// EmailRequest defines the payload for sending an email via SMTP.
+type EmailRequest struct {
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	Body    string   `json:"body"`
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/elkarto91/operary/internal/corepad"
 	"github.com/elkarto91/operary/internal/equiptrust"
 	"github.com/elkarto91/operary/internal/flowgrid"
+	"github.com/elkarto91/operary/internal/integrations"
 	"github.com/elkarto91/operary/internal/opsmirror"
 	"github.com/elkarto91/operary/internal/permitgrid"
 	"github.com/elkarto91/operary/internal/sensorvault"
@@ -44,6 +45,7 @@ func main() {
 	sensorvault.Init(db)
 	trainops.Init(db)
 	supplymesh.Init(db)
+	integrations.Init(db)
 
 	services.StartNotificationService(sugar)
 

--- a/backend/router/routes.go
+++ b/backend/router/routes.go
@@ -10,6 +10,7 @@ import (
 	"github.com/elkarto91/operary/internal/equiptrust"
 	"github.com/elkarto91/operary/internal/flowgrid"
 	"github.com/elkarto91/operary/internal/handlers"
+	"github.com/elkarto91/operary/internal/integrations"
 	authmiddleware "github.com/elkarto91/operary/internal/middleware"
 	"github.com/elkarto91/operary/internal/opsmirror"
 	"github.com/elkarto91/operary/internal/permitgrid"
@@ -38,6 +39,7 @@ func NewRouterWithLogger(logger *zap.SugaredLogger) http.Handler {
 	permitgrid.RegisterRoutes(r)
 	supplymesh.RegisterRoutes(r)
 	flowgrid.RegisterRoutes(r)
+	integrations.RegisterRoutes(r)
 	traceboard.RegisterRoutes(r)
 
 	r.Use(handlers.MetricsMiddleware)


### PR DESCRIPTION
## Summary
- implement new integrations module with webhook & SMTP email support
- expose `/integrations` routes in router and initialize from `main.go`
- record Prometheus metrics for webhook and email success/failure
- document SMTP environment variables in the access guide
- add OpenAPI spec `integrations.yaml`

## Testing
- `go vet ./...` *(fails: fetching toolchain blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686406347864832d87a9062e83a2efeb