### PR TITLE
Add notifier service module

### DIFF
--- a/backend/internal/notifier/handler/http.go
+++ b/backend/internal/notifier/handler/http.go
@@ -1,0 +1,38 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/elkarto91/operary/internal/notifier/usecase"
+	"github.com/go-chi/chi/v5"
+)
+
+// SendNotification handles POST /notify/send
+func SendNotification(w http.ResponseWriter, r *http.Request) {
+	var req usecase.NotificationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	notif, err := usecase.Send(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	json.NewEncoder(w).Encode(notif)
+}
+
+// ListUserNotifications handles GET /notify/user/{id}
+func ListUserNotifications(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	limitStr := r.URL.Query().Get("limit")
+	limit, _ := strconv.Atoi(limitStr)
+	notifs, err := usecase.ListUserNotifications(id, limit)
+	if err != nil {
+		http.Error(w, "failed to list", http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(notifs)
+}

--- a/backend/internal/notifier/model/notification.go
+++ b/backend/internal/notifier/model/notification.go
@@ -1,0 +1,18 @@
+package model
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// Notification represents a message delivered to a user via a specific channel
+// such as email or push notification.
+type Notification struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty" json:"id"`
+	UserID    string             `bson:"user_id" json:"user_id"`
+	Channel   string             `bson:"channel" json:"channel"`
+	Message   string             `bson:"message" json:"message"`
+	Status    string             `bson:"status" json:"status"`
+	Timestamp time.Time          `bson:"timestamp" json:"timestamp"`
+}

--- a/backend/internal/notifier/notifier.go
+++ b/backend/internal/notifier/notifier.go
@@ -1,0 +1,19 @@
+package notifier
+
+import (
+	"github.com/elkarto91/operary/internal/notifier/handler"
+	"github.com/elkarto91/operary/internal/notifier/repo"
+	"github.com/go-chi/chi/v5"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Init sets up database collections.
+func Init(db *mongo.Database) { repo.InitMongoCollection(db) }
+
+// RegisterRoutes exposes HTTP endpoints for the notifier service.
+func RegisterRoutes(r chi.Router) {
+	r.Route("/notify", func(r chi.Router) {
+		r.Post("/send", handler.SendNotification)
+		r.Get("/user/{id}", handler.ListUserNotifications)
+	})
+}

--- a/backend/internal/notifier/repo/notification_repository.go
+++ b/backend/internal/notifier/repo/notification_repository.go
@@ -1,0 +1,42 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/elkarto91/operary/internal/notifier/model"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var collection *mongo.Collection
+
+// InitMongoCollection sets the collection used for notifications.
+func InitMongoCollection(db *mongo.Database) {
+	collection = db.Collection("notifications")
+	idx := mongo.IndexModel{Keys: bson.D{{Key: "timestamp", Value: -1}}}
+	collection.Indexes().CreateOne(context.Background(), idx)
+}
+
+// Insert stores a new notification document.
+func Insert(n model.Notification) (model.Notification, error) {
+	_, err := collection.InsertOne(context.Background(), n)
+	return n, err
+}
+
+// ListByUser retrieves recent notifications for a user.
+func ListByUser(userID string, limit int) ([]model.Notification, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	opts := options.Find().SetSort(bson.M{"timestamp": -1}).SetLimit(int64(limit))
+	cur, err := collection.Find(context.Background(), bson.M{"user_id": userID}, opts)
+	if err != nil {
+		return nil, err
+	}
+	var res []model.Notification
+	if err := cur.All(context.Background(), &res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/backend/internal/notifier/usecase/notification_usecase.go
+++ b/backend/internal/notifier/usecase/notification_usecase.go
@@ -1,0 +1,106 @@
+package usecase
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/smtp"
+	"os"
+	"time"
+
+	"github.com/elkarto91/operary/internal/notifier/model"
+	"github.com/elkarto91/operary/internal/notifier/repo"
+)
+
+// NotificationRequest is the payload for sending a manual notification.
+type NotificationRequest struct {
+	UserID  string `json:"user_id"`
+	Channel string `json:"channel"`
+	Message string `json:"message"`
+}
+
+// Send dispatches a notification via the requested channel and logs the result.
+func Send(req NotificationRequest) (model.Notification, error) {
+	if req.UserID == "" || req.Channel == "" {
+		return model.Notification{}, errors.New("missing user or channel")
+	}
+	n := model.Notification{
+		UserID:    req.UserID,
+		Channel:   req.Channel,
+		Message:   req.Message,
+		Timestamp: time.Now(),
+	}
+	var err error
+	switch req.Channel {
+	case "email":
+		err = sendEmail(req.UserID, req.Message)
+	case "push":
+		err = sendPush(req.UserID, req.Message)
+	default:
+		err = fmt.Errorf("unsupported channel: %s", req.Channel)
+	}
+	if err != nil {
+		n.Status = "failed"
+	} else {
+		n.Status = "sent"
+	}
+	repo.Insert(n)
+	return n, err
+}
+
+// ListUserNotifications returns recent notifications for the given user.
+func ListUserNotifications(userID string, limit int) ([]model.Notification, error) {
+	return repo.ListByUser(userID, limit)
+}
+
+// sendEmail delivers an email using SMTP settings from environment.
+func sendEmail(to, msg string) error {
+	host := os.Getenv("SMTP_HOST")
+	port := os.Getenv("SMTP_PORT")
+	user := os.Getenv("SMTP_USER")
+	pass := os.Getenv("SMTP_PASS")
+	if host == "" || user == "" {
+		return errors.New("smtp not configured")
+	}
+	addr := fmt.Sprintf("%s:%s", host, port)
+	auth := smtp.PlainAuth("", user, pass, host)
+	body := []byte("To: " + to + "\r\nSubject: Operary Alert\r\n\r\n" + msg)
+	return smtp.SendMail(addr, auth, user, []string{to}, body)
+}
+
+// sendPush sends a push notification via Firebase Cloud Messaging.
+// user token is expected in `to` parameter.
+func sendPush(to, msg string) error {
+	key := os.Getenv("FCM_SERVER_KEY")
+	if key == "" {
+		return errors.New("fcm not configured")
+	}
+	payload := map[string]interface{}{
+		"to": to,
+		"notification": map[string]string{
+			"title": "Operary",
+			"body":  msg,
+		},
+	}
+	b, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", "https://fcm.googleapis.com/fcm/send", bytes.NewBuffer(b))
+	req.Header.Set("Authorization", "key="+key)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("fcm error: %s", resp.Status)
+	}
+	return nil
+}
+
+// TriggerFromEvent allows other modules to send notifications automatically.
+func TriggerFromEvent(eventType, userID, message string) {
+	req := NotificationRequest{UserID: userID, Channel: "push", Message: message}
+	Send(req)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elkarto91/operary/internal/eventbus"
 	"github.com/elkarto91/operary/internal/flowgrid"
 	"github.com/elkarto91/operary/internal/integrations"
+	"github.com/elkarto91/operary/internal/notifier"
 	"github.com/elkarto91/operary/internal/opsmirror"
 	"github.com/elkarto91/operary/internal/permitgrid"
 	"github.com/elkarto91/operary/internal/search"
@@ -52,6 +53,7 @@ func main() {
 	trainops.Init(db)
 	twinboard.Init(db)
 	supplymesh.Init(db)
+	notifier.Init(db)
 	eventbus.Init(db)
 	configmgr.Init(db)
 	search.Init(db)

--- a/backend/router/routes.go
+++ b/backend/router/routes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elkarto91/operary/internal/handlers"
 	"github.com/elkarto91/operary/internal/integrations"
 	authmiddleware "github.com/elkarto91/operary/internal/middleware"
+	"github.com/elkarto91/operary/internal/notifier"
 	"github.com/elkarto91/operary/internal/opsmirror"
 	"github.com/elkarto91/operary/internal/permitgrid"
 	"github.com/elkarto91/operary/internal/search"
@@ -46,6 +47,7 @@ func NewRouterWithLogger(logger *zap.SugaredLogger) http.Handler {
 	supplymesh.RegisterRoutes(r)
 	authz.RegisterRoutes(r)
 	eventbus.RegisterRoutes(r)
+	notifier.RegisterRoutes(r)
 	configmgr.RegisterRoutes(r)
 	search.RegisterRoutes(r)
 	flowgrid.RegisterRoutes(r)


### PR DESCRIPTION
## Summary
- implement new notifier service with email/FCM sending
- expose `/notify` endpoints and database model
- wire notifier into router and initialization

## Testing
- `go vet ./...` *(fails: download blocked)*
- `go build ./...` *(fails: download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68640a5ef08c832da1eec2339149c701