### PR TITLE
Fix server start error handling

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -63,5 +63,7 @@ func main() {
 	sugar.Info("📡 Starting Operary API on :8080")
 	r := router.NewRouterWithLogger(sugar)
 
-	http.ListenAndServe(":8080", r)
+	if err := http.ListenAndServe(":8080", r); err != nil {
+		sugar.Fatalw("failed to start server", "error", err)
+	}
 }


### PR DESCRIPTION
## Summary
- handle ListenAndServe errors in backend

## Testing
- `make test` *(fails: unable to download go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_686412c001cc832d8a32ad77f5c66e89